### PR TITLE
Improve logging directory handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -102,7 +102,7 @@ def translate_file(
     chunker = Chunker(large_chunk_size=large_chunk_size, small_chunk_size=small_chunk_size)
     translator = Translator(api_key=api_key, api_base=api_base, quality_level=quality_level)
     summarizer = Summarizer(api_key=api_key, api_base=api_base)
-    translator.logger.log_dir = log_dir  # 设置日志目录
+    translator.logger.set_log_dir(log_dir)  # 设置日志目录
     parser = MarkdownParser()
 
     # 读取输入文件

--- a/tests/test_translation_logger.py
+++ b/tests/test_translation_logger.py
@@ -1,0 +1,22 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from utils.translation_logger import TranslationLogger
+
+def test_set_log_dir_updates_file(tmp_path):
+    logger = TranslationLogger(log_dir=tmp_path / "old")
+    old_file = logger.current_log_file
+    new_dir = tmp_path / "new"
+    logger.set_log_dir(str(new_dir))
+    assert os.path.dirname(logger.current_log_file) == str(new_dir)
+    logger.log_segment(
+        original_text="a",
+        translated_text="b",
+        segment_index=1,
+        total_segments=1,
+    )
+    assert os.path.exists(logger.current_log_file)
+    assert logger.current_log_file != str(old_file)
+

--- a/utils/translation_logger.py
+++ b/utils/translation_logger.py
@@ -18,6 +18,12 @@ class TranslationLogger:
         self._ensure_log_dir()
         self.current_log_file = self._create_log_file()
         self.segments: List[Dict] = []
+
+    def set_log_dir(self, log_dir: str) -> None:
+        """Update the log directory and start a new log file."""
+        self.log_dir = log_dir
+        self._ensure_log_dir()
+        self.current_log_file = self._create_log_file()
         
     def _ensure_log_dir(self) -> None:
         """确保日志目录存在。"""


### PR DESCRIPTION
## Summary
- add `set_log_dir` to `TranslationLogger`
- use new helper in `main.py`
- test that logger switches directories correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840d38f14f8832e9e7ef84855822787